### PR TITLE
Bump api and client

### DIFF
--- a/pushkin/api/package.json
+++ b/pushkin/api/package.json
@@ -12,7 +12,7 @@
   "license": "MIT",
   "dependencies": {
     "build-if-changed": "^1.5.5",
-    "pushkin-api": "^1.5.4"
+    "pushkin-api": "^1.6.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.7.4",

--- a/pushkin/front-end/package.json
+++ b/pushkin/front-end/package.json
@@ -13,7 +13,7 @@
     "lint-staged": "^10.2.11",
     "prettier": "^2.0.5",
     "prop-types": "^15.7.2",
-    "pushkin-client": "1.5.0",
+    "pushkin-client": "^1.7.1",
     "react": "^18.2.0",
     "react-bootstrap": "^1.3.0",
     "react-dom": "^18.2.0",


### PR DESCRIPTION
Bumping the versions of the client and api as a result of merging https://github.com/pushkin-consortium/pushkin-client/pull/39 and https://github.com/pushkin-consortium/pushkin-api/pull/20. This can be approved after new versions of the api and client are published to npm. Also latest release of the site template will need to be rolled back. This would become 0.2.4?